### PR TITLE
Fd jolokia edit

### DIFF
--- a/templates/default/jolokia.policy.erb
+++ b/templates/default/jolokia.policy.erb
@@ -11,5 +11,7 @@
   <commands>
     <command>read</command>
     <command>list</command>
+    <command>version</command>
+    <command>search</command>
   </commands>
 </restrict>

--- a/templates/default/jolokia.policy.erb
+++ b/templates/default/jolokia.policy.erb
@@ -4,6 +4,9 @@
   <http>
     <method>get</method>
   </http>
+  <http>
+    <method>post</method>
+  </http>
 
   <commands>
     <command>read</command>

--- a/templates/default/jolokia.policy.erb
+++ b/templates/default/jolokia.policy.erb
@@ -11,7 +11,5 @@
   <commands>
     <command>read</command>
     <command>list</command>
-    <command>version</command>
-    <command>search</command>
   </commands>
 </restrict>


### PR DESCRIPTION
EV-2518: making changes in jolokia policy to be able to consume by telegraf jolokia2 input plugin. This is needed for monitoring cassandra db using trigmetry